### PR TITLE
Updates incorrect package name

### DIFF
--- a/app/src/androidTest/kotlin/com/tailoredapps/androidapptemplate/EspressoUtils.java
+++ b/app/src/androidTest/kotlin/com/tailoredapps/androidapptemplate/EspressoUtils.java
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License. */
 
-package com.tailoredapps.template;
+package com.tailoredapps.androidapptemplate;
 
 import android.content.res.Resources;
 import android.view.View;


### PR DESCRIPTION
Set the EspressoUtils package name to the correct value so that the setup script matches it for seding.